### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Logo](https://github.com/zutmkr/Studia/blob/master/praca_inz/static/logo.PNG)
 
+[![Run on Repl.it](https://repl.it/badge/github/zutmkr/dorothysDungeon)](https://repl.it/github/zutmkr/dorothysDungeon)
 
 # (Beta v0.3.0.170520.0):
 ### [CODE REFACTOR]:


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment.